### PR TITLE
Fix wercker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get -y update
 RUN apt-get -y install sudo openssh-server git curl rake bison \
     libcurl4-openssl-dev autoconf automake autotools-dev libtool \
     pkg-config zlib1g-dev libcunit1-dev libssl-dev libxml2-dev \
-    libevent-dev libjansson-dev libjemalloc-dev cython python3.4-dev make g++
+    libevent-dev libjansson-dev libjemalloc-dev cython python3.4-dev make g++ \
+    python-setuptools
 
 RUN cd /usr/local/src/ && git clone --depth 1 https://github.com/h2o/qrintf.git
 RUN cd /usr/local/src/qrintf && make install PREFIX=/usr/local

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,11 +1,17 @@
 box: wercker-labs/docker
+no-response-timeout: 10
 build:
     steps:
         - script:
             name: docker version
             code: |
-              docker -v
+              wget https://master.dockerproject.org/linux/amd64/docker
+              chmod +x docker.1
+              ./docker.1 -v
         - script:
             name: docker build
             code: |
-              docker build -t trusterd_ci .
+              sudo service docker stop
+              sudo /sbin/start-stop-daemon -b -x /pipeline/build/docker.1 -S -- daemon
+              sleep 300;echo ".";sleep 300;echo ".";sleep 300;echo "."
+              sudo ./docker.1 build -t trusterd_ci_1 .

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,5 @@
 box: wercker-labs/docker
-no-response-timeout: 10
+no-response-timeout: 30
 build:
     steps:
         - script:


### PR DESCRIPTION
wercker says that

```
make[3]: Entering directory `/usr/local/src/trusterd/mruby/build/host/mrbgems/mruby-http2/nghttp2/python'
cython -o nghttp2.c nghttp2.pyx
/usr/bin/python setup.py build
Traceback (most recent call last):
File "setup.py", line 24, in <module>
from setuptools import setup, Extension
ImportError: No module named setuptools
```

The most important messages is this line.
```
ImportError: No module named setuptools
```

This means that you have to apt-get install python-setuptools in Ubuntu.
